### PR TITLE
fix(test): replace hardcoded name in Exercise factory with sequence

### DIFF
--- a/spec/factories/exercises.rb
+++ b/spec/factories/exercises.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :exercise do
-    name { "Push-ups" }
+    sequence(:name) { |n| "Exercise #{n}" }
     description { "A basic bodyweight exercise." }
   end
 end


### PR DESCRIPTION
## Summary
- Substitui o nome fixo na factory de `Exercise` por uma sequence do FactoryBot
- Evita falhas intermitentes por violação de constraint de unicidade ao criar múltiplos registros em testes

## Changes
- `spec/factories/exercises.rb` — nome agora usa `sequence` para garantir unicidade entre instâncias

## Test plan
- [x] `bundle exec rspec spec/factories` — verde
- [x] Suite completa `bundle exec rspec` — verde (sem falhas por duplicidade de nome)

Closes #38