### PR TITLE
fix(serializers): add Blueprinter serializers and fix data leak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 #
+gem "blueprinter"
 gem "rack-cors"    # Para habilitar CORS
 gem "devise"       # Autenticação
 gem "devise-jwt"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.20)
     bigdecimal (4.0.1)
+    blueprinter (1.3.0)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
@@ -321,6 +322,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  blueprinter
   bootsnap
   brakeman
   debug

--- a/app/blueprints/exercise_blueprint.rb
+++ b/app/blueprints/exercise_blueprint.rb
@@ -1,0 +1,4 @@
+class ExerciseBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :description
+end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -1,0 +1,8 @@
+class UserBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :email, :role
+
+  view :minimal do
+    excludes :role
+  end
+end

--- a/app/blueprints/workout_plan_blueprint.rb
+++ b/app/blueprints/workout_plan_blueprint.rb
@@ -1,0 +1,8 @@
+class WorkoutPlanBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :description, :user_id
+
+  view :with_sessions do
+    association :workout_sessions, blueprint: WorkoutSessionBlueprint, view: :with_exercises
+  end
+end

--- a/app/blueprints/workout_session_blueprint.rb
+++ b/app/blueprints/workout_session_blueprint.rb
@@ -1,0 +1,8 @@
+class WorkoutSessionBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :user_id
+
+  view :with_exercises do
+    association :workout_session_exercises, blueprint: WorkoutSessionExerciseBlueprint
+  end
+end

--- a/app/blueprints/workout_session_exercise_blueprint.rb
+++ b/app/blueprints/workout_session_exercise_blueprint.rb
@@ -1,0 +1,4 @@
+class WorkoutSessionExerciseBlueprint < Blueprinter::Base
+  identifier :id
+  fields :exercise_id, :sets, :reps, :technique, :current_weight
+end

--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -5,12 +5,12 @@ class Api::V1::ExercisesController < ApplicationController
   # GET /exercises
   def index
     exercises = Exercise.all
-    render json: exercises, status: :ok
+    render json: ExerciseBlueprint.render_as_hash(exercises), status: :ok
   end
 
   # GET /exercises/:id
   def show
-    render json: @exercise, status: :ok
+    render json: ExerciseBlueprint.render_as_hash(@exercise), status: :ok
   end
 
   # POST /exercises
@@ -18,7 +18,7 @@ class Api::V1::ExercisesController < ApplicationController
     exercise = Exercise.new(exercise_params)
 
     if exercise.save
-      render json: exercise, status: :created
+      render json: ExerciseBlueprint.render_as_hash(exercise), status: :created
     else
       render json: { errors: exercise.errors.full_messages }, status: :unprocessable_content
     end
@@ -27,7 +27,7 @@ class Api::V1::ExercisesController < ApplicationController
   # PUT /exercises/:id
   def update
     if @exercise.update(exercise_params)
-      render json: @exercise, status: :ok
+      render json: ExerciseBlueprint.render_as_hash(@exercise), status: :ok
     else
       render json: { errors: @exercise.errors.full_messages }, status: :unprocessable_content
     end

--- a/app/controllers/api/v1/workout_sessions_controller.rb
+++ b/app/controllers/api/v1/workout_sessions_controller.rb
@@ -1,16 +1,16 @@
 class Api::V1::WorkoutSessionsController < ApplicationController
-  before_action :authenticate_user! # Ensure the user is signed in
+  before_action :authenticate_user!
   before_action :set_workout_session, only: %i[show update destroy]
 
   # GET /workout_sessions
   def index
     workout_sessions = current_user.workout_sessions
-    render json: workout_sessions, include: :workout_session_exercises, status: :ok
+    render json: WorkoutSessionBlueprint.render_as_hash(workout_sessions, view: :with_exercises), status: :ok
   end
 
   # GET /workout_sessions/:id
   def show
-    render json: @workout_session, include: :workout_session_exercises, status: :ok
+    render json: WorkoutSessionBlueprint.render_as_hash(@workout_session, view: :with_exercises), status: :ok
   end
 
   # POST /workout_sessions
@@ -18,7 +18,7 @@ class Api::V1::WorkoutSessionsController < ApplicationController
     workout_session = current_user.workout_sessions.build(workout_session_params)
 
     if workout_session.save
-      render json: workout_session, include: :workout_session_exercises, status: :created
+      render json: WorkoutSessionBlueprint.render_as_hash(workout_session, view: :with_exercises), status: :created
     else
       render json: { errors: workout_session.errors.full_messages }, status: :unprocessable_content
     end
@@ -27,7 +27,7 @@ class Api::V1::WorkoutSessionsController < ApplicationController
   # PUT /workout_sessions/:id
   def update
     if @workout_session.update(workout_session_params)
-      render json: @workout_session, include: :workout_session_exercises, status: :ok
+      render json: WorkoutSessionBlueprint.render_as_hash(@workout_session, view: :with_exercises), status: :ok
     else
       render json: { errors: @workout_session.errors.full_messages }, status: :unprocessable_content
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,7 +12,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def render_resource(resource)
     if resource.errors.empty?
-      render json: resource, status: :created
+      render json: UserBlueprint.render_as_hash(resource), status: :created
     else
       render json: { errors: resource.errors.full_messages }, status: :unprocessable_content
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -29,10 +29,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def respond_with(resource, _opts = {})
     render json: {
-      user: {
-        id: resource.id,
-        email: resource.email
-      },
+      user: UserBlueprint.render_as_hash(resource),
       token: current_token
     }, status: :ok
   end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -39,4 +39,15 @@ RSpec.describe 'User Registration', type: :request do
       end
     end
   end
+
+  describe 'sensitive fields' do
+    it 'does not expose sensitive fields' do
+      post '/users', params: { user: { name: 'Safe', email: 'safe@example.com', password: 'password', password_confirmation: 'password' } }
+
+      body = JSON.parse(response.body)
+      expect(body).not_to have_key('encrypted_password')
+      expect(body).not_to have_key('reset_password_token')
+      expect(body).not_to have_key('reset_password_sent_at')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adiciona a gem Blueprinter e cria serializers dedicados para cada recurso
- Corrige vazamento de dados sensíveis (como `encrypted_password`) nas respostas JSON

## Changes
- `Gemfile` — adiciona `blueprinter`
- `app/blueprints/exercise_blueprint.rb` — serializer para Exercise
- `app/blueprints/user_blueprint.rb` — serializer para User (exclui campos sensíveis)
- `app/blueprints/workout_plan_blueprint.rb` — serializer para WorkoutPlan
- `app/blueprints/workout_session_blueprint.rb` — serializer para WorkoutSession
- `app/blueprints/workout_session_exercise_blueprint.rb` — serializer para WorkoutSessionExercise
- Controllers atualizados para usar os blueprints em vez de `render json:` direto

## Test plan
- [x] `bundle exec rspec spec/requests/` — verde (respostas não expõem campos sensíveis)
- [x] Suite completa `bundle exec rspec` — verde

Closes #36