### PR TITLE
feat(workout_plans): implement CRUD for WorkoutPlans

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "devise"       # Autenticação
 gem "devise-jwt"
 gem "jwt"          # Para autenticação JWT (opcional)
 gem "dotenv-rails"
+gem "blueprinter"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.20)
     bigdecimal (4.0.1)
+    blueprinter (1.3.0)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
     brakeman (8.0.4)
@@ -321,6 +322,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  blueprinter
   bootsnap
   brakeman
   debug

--- a/app/blueprints/workout_plan_blueprint.rb
+++ b/app/blueprints/workout_plan_blueprint.rb
@@ -1,0 +1,8 @@
+class WorkoutPlanBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :description, :user_id
+
+  view :with_sessions do
+    association :workout_sessions, blueprint: WorkoutSessionBlueprint, view: :with_exercises
+  end
+end

--- a/app/blueprints/workout_session_blueprint.rb
+++ b/app/blueprints/workout_session_blueprint.rb
@@ -1,0 +1,8 @@
+class WorkoutSessionBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :user_id
+
+  view :with_exercises do
+    association :workout_session_exercises, blueprint: WorkoutSessionExerciseBlueprint
+  end
+end

--- a/app/blueprints/workout_session_exercise_blueprint.rb
+++ b/app/blueprints/workout_session_exercise_blueprint.rb
@@ -1,0 +1,4 @@
+class WorkoutSessionExerciseBlueprint < Blueprinter::Base
+  identifier :id
+  fields :exercise_id, :sets, :reps, :technique, :current_weight
+end

--- a/app/controllers/api/v1/workout_plans_controller.rb
+++ b/app/controllers/api/v1/workout_plans_controller.rb
@@ -1,0 +1,47 @@
+class Api::V1::WorkoutPlansController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_workout_plan, only: %i[show update destroy]
+
+  def index
+    workout_plans = current_user.workout_plans
+    render json: WorkoutPlanBlueprint.render_as_hash(workout_plans, view: :with_sessions), status: :ok
+  end
+
+  def show
+    render json: WorkoutPlanBlueprint.render_as_hash(@workout_plan, view: :with_sessions), status: :ok
+  end
+
+  def create
+    workout_plan = current_user.workout_plans.build(workout_plan_params)
+
+    if workout_plan.save
+      render json: WorkoutPlanBlueprint.render_as_hash(workout_plan, view: :with_sessions), status: :created
+    else
+      render json: { errors: workout_plan.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  def update
+    if @workout_plan.update(workout_plan_params)
+      render json: WorkoutPlanBlueprint.render_as_hash(@workout_plan, view: :with_sessions), status: :ok
+    else
+      render json: { errors: @workout_plan.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    @workout_plan.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_workout_plan
+    @workout_plan = current_user.workout_plans.find_by(id: params[:id])
+    render json: { error: "Workout plan not found" }, status: :not_found unless @workout_plan
+  end
+
+  def workout_plan_params
+    params.require(:workout_plan).permit(:name, :description, workout_session_ids: [])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :exercises
       resources :workout_sessions
+      resources :workout_plans
     end
   end
 

--- a/spec/factories/workout_plans.rb
+++ b/spec/factories/workout_plans.rb
@@ -2,12 +2,14 @@ FactoryBot.define do
   factory :workout_plan do
     name { "Strength Training Plan" }
     description { "A plan for building strength." }
-
     association :user
 
-    after(:create) do |workout_plan, evaluator|
-      create_list(:workout_session, 6).each do |workout_session|
-        create(:workout_plan_session, workout_plan: workout_plan, workout_session: workout_session)
+    trait :with_sessions do
+      after(:create) do |workout_plan|
+        sessions = create_list(:workout_session, 3, user: workout_plan.user)
+        sessions.each do |session|
+          create(:workout_plan_session, workout_plan: workout_plan, workout_session: session)
+        end
       end
     end
   end

--- a/spec/requests/api/v1/workout_plans_spec.rb
+++ b/spec/requests/api/v1/workout_plans_spec.rb
@@ -1,0 +1,192 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::WorkoutPlans", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:auth_headers_for) do
+    ->(u) {
+      post '/users/sign_in', params: { email: u.email, password: u.password }, as: :json
+      token = JSON.parse(response.body)["token"]
+      { "Authorization" => token, "Content-Type" => "application/json" }
+    }
+  end
+
+  let(:headers) { auth_headers_for.call(user) }
+  let(:response_body) { JSON.parse(response.body) }
+
+  describe "GET /api/v1/workout_plans" do
+    context "when authenticated" do
+      it "returns only the current user's workout plans" do
+        create(:workout_plan, user: user, name: "My Plan")
+        create(:workout_plan, user: other_user, name: "Other Plan")
+
+        get "/api/v1/workout_plans", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_body.size).to eq(1)
+        expect(response_body.first["name"]).to eq("My Plan")
+      end
+    end
+
+    context "when unauthenticated" do
+      it "returns unauthorized status" do
+        get "/api/v1/workout_plans"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/workout_plans/:id" do
+    let(:workout_plan) { create(:workout_plan, user: user) }
+
+    context "when authenticated" do
+      it "returns the workout plan" do
+        get "/api/v1/workout_plans/#{workout_plan.id}", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_body["id"]).to eq(workout_plan.id)
+        expect(response_body["name"]).to eq(workout_plan.name)
+      end
+
+      it "returns not found for a non-existing workout plan" do
+        get "/api/v1/workout_plans/999", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(response_body["error"]).to eq("Workout plan not found")
+      end
+
+      it "returns not found for another user's workout plan" do
+        other_plan = create(:workout_plan, user: other_user)
+        get "/api/v1/workout_plans/#{other_plan.id}", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(response_body["error"]).to eq("Workout plan not found")
+      end
+    end
+
+    context "when unauthenticated" do
+      it "returns unauthorized status" do
+        get "/api/v1/workout_plans/#{workout_plan.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "POST /api/v1/workout_plans" do
+    let(:valid_params) do
+      { workout_plan: { name: "New Plan", description: "A new plan" } }
+    end
+
+    context "when authenticated" do
+      it "creates a workout plan with name and description" do
+        expect {
+          post "/api/v1/workout_plans", params: valid_params.to_json, headers: headers
+        }.to change(WorkoutPlan, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response_body["name"]).to eq("New Plan")
+        expect(response_body["description"]).to eq("A new plan")
+      end
+
+      it "can receive workout_session_ids" do
+        session1 = create(:workout_session, user: user)
+        session2 = create(:workout_session, user: user)
+
+        params = { workout_plan: { name: "Plan With Sessions", workout_session_ids: [ session1.id, session2.id ] } }
+        post "/api/v1/workout_plans", params: params.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        expect(response_body["workout_sessions"].size).to eq(2)
+      end
+
+      it "returns unprocessable entity when name is blank" do
+        post "/api/v1/workout_plans", params: { workout_plan: { name: "" } }.to_json, headers: headers
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response_body["errors"]).to include("Name can't be blank")
+      end
+    end
+
+    context "when unauthenticated" do
+      it "returns unauthorized status" do
+        post "/api/v1/workout_plans", params: valid_params.to_json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "PUT /api/v1/workout_plans/:id" do
+    let(:workout_plan) { create(:workout_plan, user: user, name: "Old Name") }
+
+    context "when authenticated" do
+      it "updates the workout plan" do
+        put "/api/v1/workout_plans/#{workout_plan.id}",
+            params: { workout_plan: { name: "New Name" } }.to_json,
+            headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_body["name"]).to eq("New Name")
+      end
+
+      it "returns unprocessable entity when name is blank" do
+        put "/api/v1/workout_plans/#{workout_plan.id}",
+            params: { workout_plan: { name: "" } }.to_json,
+            headers: headers
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response_body["errors"]).to include("Name can't be blank")
+      end
+
+      it "returns not found for a non-existing workout plan" do
+        put "/api/v1/workout_plans/999",
+            params: { workout_plan: { name: "Updated" } }.to_json,
+            headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(response_body["error"]).to eq("Workout plan not found")
+      end
+    end
+
+    context "when unauthenticated" do
+      it "returns unauthorized status" do
+        put "/api/v1/workout_plans/#{workout_plan.id}",
+            params: { workout_plan: { name: "Updated" } }.to_json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/workout_plans/:id" do
+    let!(:workout_plan) { create(:workout_plan, user: user) }
+
+    context "when authenticated" do
+      it "deletes the workout plan" do
+        expect {
+          delete "/api/v1/workout_plans/#{workout_plan.id}", headers: headers
+        }.to change(WorkoutPlan, :count).by(-1)
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "returns not found for a non-existing workout plan" do
+        delete "/api/v1/workout_plans/999", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(response_body["error"]).to eq("Workout plan not found")
+      end
+    end
+
+    context "when unauthenticated" do
+      it "returns unauthorized status" do
+        delete "/api/v1/workout_plans/#{workout_plan.id}"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implementa endpoints CRUD completos para `WorkoutPlan`
- Cada usuário gerencia apenas seus próprios planos (scoped por `current_user`)

## Changes
- `app/controllers/api/v1/workout_plans_controller.rb` — controller com index, show, create, update e destroy
- `config/routes.rb` — adiciona rotas para `workout_plans` sob `/api/v1`
- `spec/requests/api/v1/workout_plans_spec.rb` — request specs cobrindo todos os endpoints e cenários de autorização

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/workout_plans_spec.rb` — verde
- [x] Suite completa `bundle exec rspec` — verde

Closes #40