### PR TITLE
chore(deps): remove redundant jwt gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ gem "bootsnap", require: false
 gem "rack-cors"    # Para habilitar CORS
 gem "devise"       # Autenticação
 gem "devise-jwt"
-gem "jwt"          # Para autenticação JWT (opcional)
 gem "dotenv-rails"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,6 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (~> 6.2)
   ffaker
-  jwt
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)


### PR DESCRIPTION
## Summary
- Removes the `jwt` gem which is already provided as a dependency of `devise-jwt`
- Avoids potential version conflicts from having the same gem declared twice

## Changes
- `Gemfile`: removed redundant `gem "jwt"` line
- `Gemfile.lock`: updated accordingly

## Test plan
- [x] `bundle exec rspec` — all green (no behavior changes expected)

Closes #46