### PR TITLE
chore(ci): remove unnecessary dependencies from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Removes `google-chrome-stable` and `libvips` from the apt-get install step in CI
- These packages are not used by the API (no system tests, no image processing)
- Reduces CI build time by skipping unnecessary downloads

## Changes
- `.github/workflows/ci.yml`: removed unused packages from apt install command

## Test plan
- [x] CI pipeline passes after this change
- [x] `bundle exec rspec` — all green

Closes #47