### PR TITLE
fix(model): add dependent destroy to Exercise has_many association

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,6 +1,6 @@
 class Exercise < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
-  has_many :workout_session_exercises
+  has_many :workout_session_exercises, dependent: :destroy
   has_many :workout_sessions, through: :workout_session_exercises
 end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Exercise, type: :model do
   end
 
   describe 'associations' do
-    it { should have_many(:workout_session_exercises) }
+    it { should have_many(:workout_session_exercises).dependent(:destroy) }
     it { should have_many(:workout_sessions).through(:workout_session_exercises) }
   end
 end


### PR DESCRIPTION
## Summary
- Adds `dependent: :destroy` to the `has_many :workout_session_exercises` association in `Exercise`
- Prevents orphaned `workout_session_exercises` records when an `Exercise` is deleted

## Changes
- `app/models/exercise.rb`: updated has_many to include `dependent: :destroy`
- `spec/models/exercise_spec.rb`: updated association spec to match

## Test plan
- [x] `bundle exec rspec spec/models/exercise_spec.rb` — green
- [x] `bundle exec rspec` — all green

Closes #48