### PR TITLE
fix(performance): resolve N+1 in WorkoutSessions#index

### DIFF
--- a/app/controllers/api/v1/workout_sessions_controller.rb
+++ b/app/controllers/api/v1/workout_sessions_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::WorkoutSessionsController < ApplicationController
 
   # GET /workout_sessions
   def index
-    workout_sessions = current_user.workout_sessions
+    workout_sessions = current_user.workout_sessions.includes(:workout_session_exercises)
     render json: WorkoutSessionBlueprint.render_as_hash(workout_sessions, view: :with_exercises), status: :ok
   end
 


### PR DESCRIPTION
## Summary
- Adds `includes(:workout_session_exercises)` to the index query in `WorkoutSessionsController`
- Eliminates the N+1 query that fired one SQL per session when loading exercises

## Changes
- `app/controllers/api/v1/workout_sessions_controller.rb`: eager load workout_session_exercises in index

## Test plan
- [ ] `bundle exec rspec spec/requests/api/v1/workout_sessions_spec.rb` — green
- [ ] `bundle exec rspec` — all green

Closes #43