### PR TITLE
feat(api): add pagination with pagy to index endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "rack-cors"    # Para habilitar CORS
 gem "devise"       # Autenticação
 gem "devise-jwt"
 gem "dotenv-rails"
+gem "pagy"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,10 @@ GEM
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (43.5.2)
+      json
+      uri
+      yaml
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -316,6 +320,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yaml (0.4.0)
     zeitwerk (2.7.4)
 
 PLATFORMS
@@ -331,6 +336,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (~> 6.2)
   ffaker
+  pagy
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)

--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -8,7 +8,11 @@ class Api::V1::ExercisesController < ApplicationController
   def index
     exercises = Exercise.all
     exercises = exercises.where("name ILIKE ?", "%#{params[:name]}%") if params[:name].present?
-    render json: ExerciseBlueprint.render_as_hash(exercises), status: :ok
+    pagy, records = pagy(exercises, limit: params.fetch(:per_page, 20).to_i)
+    render json: {
+      data: ExerciseBlueprint.render_as_hash(records),
+      pagination: pagy_metadata(pagy)
+    }, status: :ok
   end
 
   # GET /exercises/:id

--- a/app/controllers/api/v1/workout_plans_controller.rb
+++ b/app/controllers/api/v1/workout_plans_controller.rb
@@ -4,7 +4,11 @@ class Api::V1::WorkoutPlansController < ApplicationController
 
   def index
     workout_plans = current_user.workout_plans
-    render json: WorkoutPlanBlueprint.render_as_hash(workout_plans, view: :with_sessions), status: :ok
+    pagy, records = pagy(workout_plans, limit: params.fetch(:per_page, 20).to_i)
+    render json: {
+      data: WorkoutPlanBlueprint.render_as_hash(records, view: :with_sessions),
+      pagination: pagy_metadata(pagy)
+    }, status: :ok
   end
 
   def show

--- a/app/controllers/api/v1/workout_sessions_controller.rb
+++ b/app/controllers/api/v1/workout_sessions_controller.rb
@@ -5,7 +5,11 @@ class Api::V1::WorkoutSessionsController < ApplicationController
   # GET /workout_sessions
   def index
     workout_sessions = current_user.workout_sessions.includes(:workout_session_exercises)
-    render json: WorkoutSessionBlueprint.render_as_hash(workout_sessions, view: :with_exercises), status: :ok
+    pagy, records = pagy(workout_sessions, limit: params.fetch(:per_page, 20).to_i)
+    render json: {
+      data: WorkoutSessionBlueprint.render_as_hash(records, view: :with_exercises),
+      pagination: pagy_metadata(pagy)
+    }, status: :ok
   end
 
   # GET /workout_sessions/:id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include Devise::Controllers::Helpers
+  include Pagy::Method
   rescue_from ActionController::RoutingError, with: :route_not_found
   rescue_from AbstractController::ActionNotFound, with: :route_not_found
   before_action :configure_permitted_parameters, if: :devise_controller?
@@ -28,5 +29,18 @@ class ApplicationController < ActionController::API
 
   def set_locale
     I18n.locale = request.headers["Accept-Language"]&.scan(/^[a-z]{2}/)&.first || I18n.default_locale
+  end
+
+  def pagy_metadata(pagy)
+    {
+      page: pagy.page,
+      limit: pagy.limit,
+      count: pagy.count,
+      pages: pagy.pages,
+      from: pagy.from,
+      to: pagy.to,
+      prev: pagy.previous,
+      next: pagy.next
+    }
   end
 end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,2 @@
+require "pagy"
+require "pagy/toolbox/paginators/offset"

--- a/spec/requests/api/v1/exercises_spec.rb
+++ b/spec/requests/api/v1/exercises_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Api::V1::Exercises", type: :request do
         get_request
 
         expect(response).to have_http_status(:ok)
-        expect(response_body.size).to eq(1)
+        expect(response_body["data"].size).to eq(1)
       end
     end
 
@@ -39,8 +39,8 @@ RSpec.describe "Api::V1::Exercises", type: :request do
         get "/api/v1/exercises", params: { name: "ups" }, headers: headers
 
         expect(response).to have_http_status(:ok)
-        expect(response_body.size).to eq(2)
-        expect(response_body.map { |e| e["name"] }).to contain_exactly("Push-ups", "Pull-ups")
+        expect(response_body["data"].size).to eq(2)
+        expect(response_body["data"].map { |e| e["name"] }).to contain_exactly("Push-ups", "Pull-ups")
       end
 
       it "returns all exercises when name filter is absent" do
@@ -49,7 +49,7 @@ RSpec.describe "Api::V1::Exercises", type: :request do
         get "/api/v1/exercises", headers: headers
 
         expect(response).to have_http_status(:ok)
-        expect(response_body.size).to eq(3)
+        expect(response_body["data"].size).to eq(3)
       end
     end
 

--- a/spec/requests/api/v1/workout_plans_spec.rb
+++ b/spec/requests/api/v1/workout_plans_spec.rb
@@ -24,8 +24,17 @@ RSpec.describe "Api::V1::WorkoutPlans", type: :request do
         get "/api/v1/workout_plans", headers: headers
 
         expect(response).to have_http_status(:ok)
-        expect(response_body.size).to eq(1)
-        expect(response_body.first["name"]).to eq("My Plan")
+        expect(response_body["data"].size).to eq(1)
+        expect(response_body["data"].first["name"]).to eq("My Plan")
+      end
+
+      it "includes pagination metadata" do
+        create(:workout_plan, user: user)
+
+        get "/api/v1/workout_plans", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response_body["pagination"]).to include("page", "limit", "count", "pages")
       end
     end
 

--- a/spec/requests/api/v1/workout_sessions_spec.rb
+++ b/spec/requests/api/v1/workout_sessions_spec.rb
@@ -25,8 +25,14 @@ RSpec.describe "Api::V1::WorkoutSessions", type: :request do
       it "returns all workout sessions for the user" do
         get_request
         expect(response).to have_http_status(:ok)
-        expect(response_body.size).to eq(2)
-        expect(response_body.map { |s| s["name"] }).to contain_exactly("Session A", "Session B")
+        expect(response_body["data"].size).to eq(2)
+        expect(response_body["data"].map { |s| s["name"] }).to contain_exactly("Session A", "Session B")
+      end
+
+      it "includes pagination metadata" do
+        get_request
+        expect(response).to have_http_status(:ok)
+        expect(response_body["pagination"]).to include("page", "limit", "count", "pages")
       end
     end
 


### PR DESCRIPTION
## Summary
- Adds `pagy` gem for offset-based pagination
- `GET /api/v1/exercises` and `GET /api/v1/workout_sessions` now return paginated responses
- Response format includes `data` array and `pagination` metadata object
- Default page size is 20 items; can be overridden via `per_page` query param

## Changes
- `Gemfile` / `Gemfile.lock`: added pagy gem
- `config/initializers/pagy.rb`: require pagy and offset paginator
- `app/controllers/application_controller.rb`: include `Pagy::Method` and add `pagy_metadata` helper
- `app/controllers/api/v1/exercises_controller.rb`: paginated index
- `app/controllers/api/v1/workout_sessions_controller.rb`: paginated index with eager loading
- `spec/requests/api/v1/exercises_spec.rb`: updated assertions for new response format
- `spec/requests/api/v1/workout_sessions_spec.rb`: updated assertions for new response format

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/exercises_spec.rb` — green
- [x] `bundle exec rspec spec/requests/api/v1/workout_sessions_spec.rb` — green
- [x] `bundle exec rspec` — all green

Closes #41