### PR TITLE
fix(ci): provide fallback SECRET_KEY_BASE for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/gym_app_test
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE || 'test-secret-key-base-for-ci-only' }}
         run: |
           bin/rails db:create db:schema:load
 
@@ -82,5 +83,5 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/gym_app_test
-          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE || 'test-secret-key-base-for-ci-only' }}
         run: bundle exec rspec --force-color spec/


### PR DESCRIPTION
## Problem

GitHub Actions does not expose repository secrets to Dependabot PRs by
default (security restriction introduced in 2021). All 8 Dependabot bump
PRs (#28–#35) were failing the \`test\` job with:

\`\`\`
ArgumentError: \`secret_key_base\` for test environment must be a type of String
\`\`\`

because \`SECRET_KEY_BASE\` was arriving as an empty string instead of the
secret value.

## Fix

Use GitHub Actions expression syntax to fall back to a static placeholder
string when the secret is not available:

\`\`\`yaml
SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE || 'test-secret-key-base-for-ci-only' }}
\`\`\`

This is safe because:
- The fallback value is only used in the \`test\` environment
- It is never used in production (production reads the real secret)
- The value is not a secret — it only needs to be a non-empty string for Rails to boot

The same fallback was added to the \`db:create\` step, which loads the Rails
environment and would hit the same error.

## Checklist
- [x] CI green on this PR before merging
- [x] No application code changed — workflow only