### PR TITLE
fix(user): default role to member on self-registration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     blueprinter (1.3.0)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     byebug (13.0.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,9 +6,12 @@ class User < ApplicationRecord
   has_many :workout_plans, dependent: :destroy
   has_many :workout_sessions, dependent: :destroy
 
+  ROLES = %w[admin member].freeze
+
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :name, presence: true
   validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
+  validates :role, inclusion: { in: ROLES }, allow_nil: false
 
   private
 

--- a/db/migrate/20260711184244_set_default_role_on_users.rb
+++ b/db/migrate/20260711184244_set_default_role_on_users.rb
@@ -1,0 +1,13 @@
+class SetDefaultRoleOnUsers < ActiveRecord::Migration[8.1]
+  def up
+    execute "UPDATE users SET role = 'member' WHERE role IS NULL"
+
+    change_column_default :users, :role, from: nil, to: 'member'
+    change_column_null :users, :role, false
+  end
+
+  def down
+    change_column_null :users, :role, true
+    change_column_default :users, :role, from: 'member', to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_02_15_154031) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_11_184244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -37,7 +37,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_02_15_154031) do
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
-    t.string "role"
+    t.string "role", default: "member", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,4 +1,5 @@
 
 
 User.create(name: 'User', email: 'admin@email.com', password: '123456789', password_confirmation: '123456789', role: 'admin')
+User.create(name: 'Member', email: 'member@email.com', password: '123456789', password_confirmation: '123456789', role: 'member')
 puts "✅ Users seeds loaded successfully!"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,5 +28,20 @@ RSpec.describe User, type: :model do
       user.name = 'New Name'
       expect(user).to be_valid
     end
+
+    it 'defaults role to member when not set' do
+      user = create(:user)
+      expect(user.role).to eq('member')
+    end
+
+    it 'is valid with role admin' do
+      subject.role = 'admin'
+      expect(subject).to be_valid
+    end
+
+    it 'is not valid with a role outside the allowed list' do
+      subject.role = 'superadmin'
+      expect(subject).not_to be_valid
+    end
   end
 end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe 'User Registration', type: :request do
     end
   end
 
+  describe 'role assignment' do
+    it 'assigns the default member role on self-registration' do
+      post '/users', params: { user: { name: 'Test', email: 'member@example.com', password: 'password', password_confirmation: 'password' } }
+
+      expect(User.find_by(email: 'member@example.com').role).to eq('member')
+    end
+
+    it 'ignores a role param injected in the payload to prevent privilege escalation' do
+      post '/users', params: {
+        user: {
+          name: 'Attacker', email: 'attacker@example.com', password: 'password',
+          password_confirmation: 'password', role: 'admin'
+        }
+      }
+
+      expect(response).to have_http_status(:created)
+      expect(User.find_by(email: 'attacker@example.com').role).to eq('member')
+    end
+  end
+
   describe 'sensitive fields' do
     it 'does not expose sensitive fields' do
       post '/users', params: { user: { name: 'Safe', email: 'safe@example.com', password: 'password', password_confirmation: 'password' } }


### PR DESCRIPTION
## Summary
- Self-registered users were getting `role: nil` — `sign_up_params` never permitted `role`, and the column had no default.
- `users.role` now defaults to `"member"` at the DB level (migration backfills existing `NULL` rows), with `NOT NULL` enforced.
- `User` model restricts `role` to `admin`/`member` via inclusion validation.
- Registration payload still cannot set `role` directly, so a client can't escalate to `admin` — covered by a regression test.
- Added a seeded `member` user alongside the existing `admin` seed for local dev/testing.

## Test plan
- [x] `bundle exec rspec` — 93 examples, 0 failures
- [x] `rubocop` — no offenses
- [ ] Manual: register a new user via `/register` on the web app and confirm `role` comes back as `member`